### PR TITLE
:beetle: scope formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function format(answers) {
   const scope = answers.scope ? '(' + answers.scope.trim() + ') ' : ''
 
   // build head line and limit it to 100
-  const head = truncate(answers.type + ' ' + answers.scope + answers.subject.trim(), 100)
+  const head = truncate(answers.type + ' ' + scope + answers.subject.trim(), 100)
 
   // wrap body at 100
   const body = wrap(answers.body, 100)


### PR DESCRIPTION
Should use the formatted scope instead of just the `answer` string