### PR TITLE
🐛 Fix exception if no package.json is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ function getEmojiChoices(types) {
  * @private
  */
 function createQuestions(res) {
-  const config = res.pkg.config || {}
+  const pkg = res.pkg || {}
+  const config = pkg.config || {}
   const emojiConfig = config['cz-emoji'] || {}
 
   return [


### PR DESCRIPTION
If no package.json could be found cz-emoji would throw an exception when trying to access res.pkg.config.

`read-pkg-up` returns `null` and not `{}` so naturally this would throw an exception.