### PR TITLE
Fuzzy-search emojis, insert real unicode symbols option, read config from .czrc

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const defaultConfig = {
   symbol: false
 }
 
-function getEmojiChoices({types, symbol}) {
+function getEmojiChoices({ types, symbol }) {
   const maxNameLength = types.reduce(
     (maxLength, type) => (type.name.length > maxLength ? type.name.length : maxLength
   ), 0)
@@ -27,16 +27,18 @@ function getEmojiChoices({types, symbol}) {
 }
 
 function loadConfig() {
+  const getConfig = (obj) => obj && obj.config && obj.config['cz-emoji']
+
   return readPkg()
     .then(({ pkg }) => {
-      const config = (pkg && pkg.config && pkg.config['cz-emoji'])
+      const config = getConfig(pkg)
       if (config) return config
 
       return new Promise((resolve, reject) => {
         fs.readFile(homeDir('.czrc'), 'utf8', (err, content) => {
           if (err) reject(err)
           const czrc = JSON.parse(content) || null
-          resolve((czrc && czrc.config && czrc.config['cz-emoji']) || {})
+          resolve(getConfig(czrc))
         })
       })
     })

--- a/index.js
+++ b/index.js
@@ -8,14 +8,14 @@ const fuse = require('fuse.js')
 const Promise = require('bluebird')
 const types = require('./lib/types')
 
-function getEmojiChoices(types) {
+function getEmojiChoices(types, symbol) {
   const maxNameLength = types.reduce(
     (maxLength, type) => (type.name.length > maxLength ? type.name.length : maxLength
   ), 0)
 
   return types.map(choice => ({
     name: `${pad(choice.name, maxNameLength)}  ${choice.emoji}  ${choice.description}`,
-    value: choice.code
+    value: symbol ? choice.emoji : choice.code
   }))
 }
 
@@ -32,7 +32,7 @@ function createQuestions(res) {
   const config = pkg.config || {}
   const emojiConfig = config['cz-emoji'] || {}
 
-  const choices = getEmojiChoices(emojiConfig.types || types)
+  const choices = getEmojiChoices(emojiConfig.types || types, emojiConfig.symbol || false)
   const fuzzy = new fuse(choices, {
     keys: ['name'],
     shouldSort: true,

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function createQuestions(config) {
     {
       type: 'input',
       name: 'issues',
-      message: 'List any issue closed:'
+      message: 'List any issue closed (#1 #2 #3 ...):'
     },
     {
       type: 'input',
@@ -110,7 +110,17 @@ function format(answers) {
   // wrap body at 100
   const body = wrap(answers.body, 100)
 
-  return (head + '\n\n' + body)
+  let commitmsg = head + '\n\n' + body
+
+  const issues = answers.issues.match(/#\d+/g)
+  if (issues && issues.length > 0) {
+    commitmsg += '\n'
+    issues.forEach((i) => {
+      commitmsg += '\nCloses ' + i
+    })
+  }
+
+  return commitmsg
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -117,17 +117,13 @@ function format(answers) {
   // wrap body at 100
   const body = wrap(answers.body, 100)
 
-  let commitmsg = head + '\n\n' + body
+  const footer = (answers.issues.match(/#\d+/g) || [])
+  .map(issue => `Closes ${issue}`)
+  .join('\n')
 
-  const issues = answers.issues.match(/#\d+/g)
-  if (issues && issues.length > 0) {
-    commitmsg += '\n'
-    issues.forEach((i) => {
-      commitmsg += '\nCloses ' + i
-    })
-  }
-
-  return commitmsg
+  return [head, body, footer]
+    .join('\n\n')
+    .trim()
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ function getEmojiChoices(types) {
  * @private
  */
 function createQuestions(res) {
-  const config = res.pkg.config || {}
+  const pkg = res.pkg || {}
+  const config = pkg.config || {}
   const emojiConfig = config['cz-emoji'] || {}
 
   return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,51 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ansi-escapes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ=="
+    },
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
+    "ansi-styles": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "requires": {
+        "color-convert": "1.9.0"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
+    "chalk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "4.5.0"
+      }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "2.0.0"
+      }
     },
     "cli-truncate": {
       "version": "1.0.0",
@@ -23,10 +59,28 @@
         "string-width": "2.1.0"
       }
     },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+    },
     "clone": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "defaults": {
       "version": "1.0.3",
@@ -44,6 +98,29 @@
         "is-arrayish": "0.2.1"
       }
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "external-editor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "requires": {
+        "iconv-lite": "0.4.19",
+        "jschardet": "1.6.0",
+        "tmp": "0.0.33"
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -52,15 +129,76 @@
         "locate-path": "2.0.0"
       }
     },
+    "fuse.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.0.tgz",
+      "integrity": "sha1-8ESOgGmFW/Kj5oPNwdMg5+KgfvQ="
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+    },
+    "inquirer": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.0.tgz",
+      "integrity": "sha512-4CyUYMP7lOBkiUU1rR24WGrfRX6SucwbY2Mqb1PdApU24wnTIk4TsnkQwV72dDdIKZ2ycLP+fWCV+tA7wwgoew==",
+      "requires": {
+        "ansi-escapes": "2.0.0",
+        "chalk": "2.3.0",
+        "cli-cursor": "2.1.0",
+        "cli-width": "2.2.0",
+        "external-editor": "2.0.5",
+        "figures": "2.0.0",
+        "lodash": "4.17.4",
+        "mute-stream": "0.0.7",
+        "run-async": "2.3.0",
+        "rx-lite": "4.0.8",
+        "rx-lite-aggregates": "4.0.8",
+        "string-width": "2.1.0",
+        "strip-ansi": "4.0.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs="
+        }
+      }
+    },
+    "inquirer-autocomplete-prompt": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer-autocomplete-prompt/-/inquirer-autocomplete-prompt-0.12.0.tgz",
+      "integrity": "sha512-TfsWkiQjFt076Cd6kvfhGLTwAGrdquvPvsncSaUeSSl2GfHVa6Scmy0XaGyFcU6q848koEXp0bSL3s/0F+1Icg==",
+      "requires": {
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.0",
+        "figures": "2.0.0",
+        "inquirer": "3.2.0",
+        "run-async": "2.3.0",
+        "util": "0.10.3"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -79,6 +217,16 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "jschardet": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -100,6 +248,21 @@
         "path-exists": "3.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "mimic-fn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -110,6 +273,19 @@
         "semver": "5.3.0",
         "validate-npm-package-license": "3.0.1"
       }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "1.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "p-limit": {
       "version": "1.1.0",
@@ -177,10 +353,45 @@
         "read-pkg": "2.0.0"
       }
     },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "requires": {
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "4.0.8"
+      }
+    },
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -226,6 +437,35 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+    },
+    "supports-color": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "requires": {
+        "inherits": "2.0.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -129,6 +129,16 @@
         "locate-path": "2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
+      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
     "fuse.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.2.0.tgz",
@@ -143,6 +153,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
+    "home-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/home-dir/-/home-dir-1.0.0.tgz",
+      "integrity": "sha1-KRfrRL3JByztqUJXlUOEfjAX/k4="
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -227,6 +242,14 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -458,6 +481,11 @@
       "requires": {
         "os-tmpdir": "1.0.2"
       }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "util": {
       "version": "0.10.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,6 @@
         "color-convert": "1.9.0"
       }
     },
-    "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -127,16 +122,6 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
         "locate-path": "2.0.0"
-      }
-    },
-    "fs-extra": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
       }
     },
     "fuse.js": {
@@ -242,14 +227,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
       "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ=="
-    },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -481,11 +458,6 @@
       "requires": {
         "os-tmpdir": "1.0.2"
       }
-    },
-    "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "util": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,11 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "cli-truncate": "^1.0.0",
+    "fs-extra": "^4.0.2",
     "fuse.js": "^3.2.0",
+    "home-dir": "^1.0.0",
     "inquirer-autocomplete-prompt": "^0.12.0",
+    "lodash": "^4.17.4",
     "pad": "^2.0.1",
     "read-pkg-up": "^2.0.0",
     "wrap-ansi": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -19,13 +19,10 @@
     "emoji"
   ],
   "dependencies": {
-    "bluebird": "^3.5.1",
     "cli-truncate": "^1.0.0",
-    "fs-extra": "^4.0.2",
     "fuse.js": "^3.2.0",
     "home-dir": "^1.0.0",
     "inquirer-autocomplete-prompt": "^0.12.0",
-    "lodash": "^4.17.4",
     "pad": "^2.0.1",
     "read-pkg-up": "^2.0.0",
     "wrap-ansi": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "emoji"
   ],
   "dependencies": {
+    "bluebird": "^3.5.1",
     "cli-truncate": "^1.0.0",
+    "fuse.js": "^3.2.0",
+    "inquirer-autocomplete-prompt": "^0.12.0",
     "pad": "^2.0.1",
     "read-pkg-up": "^2.0.0",
     "wrap-ansi": "^3.0.0"


### PR DESCRIPTION
- I added support for fuzzy searching the emoji list. Scrolling using my arrow keys got quite exhausting.
- I added support for an option called `symbol`. If it is set to `true`, we insert the unicode emoji instead of its textual representation.
- If there is no `package.json` with options for cz-emoji, look in the `.czrc`.

My `.czrc` looks like this:

```json
{
  "config": {
    "cz-emoji": {
      "symbol": true
    }
  },
  "path": "cz-emoji"
}
```

I did not add anything to the README (yet) as I'm not really good at the whole write-a-readme-thingy. And please excuse my ugly javascript, I use coffeescript 99.9999% of the time so my javascript is basic at most.

Example:
![2017-11-08_21-06-02](https://user-images.githubusercontent.com/5219415/32571996-912bdb54-c4c9-11e7-98f6-b1ae0e8b9517.gif)
