### PR TITLE
Bug: Poop emoji rendering

### DIFF
--- a/lib/types.json
+++ b/lib/types.json
@@ -193,7 +193,7 @@
   },
   {
     "emoji": "💩",
-    "code": ":hankey:",
+    "code": ":poop:",
     "description": "Writing bad code that needs to be improved.",
     "name": "poo"
   },


### PR DESCRIPTION
The sh*t emoji is not recognised by hankey in bitbucket, however github and bitbucket both recognize poop

That is: 
  - Hankey: :hankey:
  - Poop: :poop:

Please ignore this PR if it is not urgent. :) 

Example from a private repo at work:

![hankey](https://user-images.githubusercontent.com/11262664/36714211-f02e14a4-1bdc-11e8-8edd-269e44e34952.png)
