### PR TITLE
fix bug where adapter crashes if there is no .czrc

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ function loadConfig() {
       return new Promise((resolve, reject) => {
         fs.readFile(homeDir('.czrc'), 'utf8', (err, content) => {
           if (err) reject(err)
-          const czrc = JSON.parse(content) || null
+          const czrc = content && JSON.parse(content) || null
           resolve(getConfig(czrc))
         })
       })


### PR DESCRIPTION
I'm not sure if this is related to my node version (9.11.1) or is the expected behavior, but if I do not have `.czrc`. the `readFile` callback is not called with a valid `err`, but the `content` is undefined. So the `JSON.parse(content)` throws an error not captured by the promise and the adapter fails. I had to put this simple validation before calling it. 

it does not alter the behavior if you do have the `.czrc`. 