### PR TITLE
📝 (Readme) Adding symbol config and cleaning up Customization Section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,11 +28,13 @@ echo '{ "path": "cz-emoji" }' > ~/.czrc
 $ git cz
 ```
 
-## Customize
+## Customization
 
-By default `cz-emoji` comes preconfigured with the [Gitmoji](https://gitmoji.carloscuesta.me/) types.
+By default `cz-emoji` comes ready to run out of the box. Uses may vary, so there are a few configuration options to allow fine tuning for project needs.
 
-But you can customize things on a project basis by adding a configuration section in your `package.json`:
+### How to
+
+Configuring `cz-emoji` can be handled in the users home directory (`~/.czrc`) for changes to impact all projects or on a per project basis (`package.json`). Simply add the config property as shown below to the existing object in either of the locations with your settings for override.
 
 ```json
 {
@@ -42,7 +44,11 @@ But you can customize things on a project basis by adding a configuration sectio
 }
 ```
 
-### Types
+### Configuration Options
+
+#### Types
+
+By default `cz-emoji` comes preconfigured with the [Gitmoji](https://gitmoji.carloscuesta.me/) types.
 
 An [Inquirer.js] choices array:
 
@@ -63,9 +69,7 @@ An [Inquirer.js] choices array:
 }
 ```
 
-The value `property` must be the emoji itself.
-
-### Scopes
+#### Scopes
 
 An [Inquirer.js] choices array:
 
@@ -79,9 +83,9 @@ An [Inquirer.js] choices array:
 }
 ```
 
-### Symbol
+#### Symbol
 
-A boolean value that allows for an using a unicode value rather than the default of gitmoji markup in a commit message. The default for symbol is false.
+A boolean value that allows for an using a unicode value rather than the default of [Gitmoji](https://gitmoji.carloscuesta.me/) markup in a commit message. The default for symbol is false.
 
 ```json
 {

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,6 @@
 
 > Commitizen adapter formatting commit messages using emojis.
 
-
 **cz-emoji** allows you to easily use emojis in your commits using [commitizen].
 
 ```sh
@@ -46,6 +45,7 @@ But you can customize things on a project basis by adding a configuration sectio
 ### Types
 
 An [Inquirer.js] choices array:
+
 ```json
 {
   "config": {
@@ -68,15 +68,26 @@ The value `property` must be the emoji itself.
 ### Scopes
 
 An [Inquirer.js] choices array:
+
 ```json
 {
   "config": {
     "cz-emoji": {
-      "scopes": [
-        "home",
-        "accounts",
-        "ci"
-      ]
+      "scopes": ["home", "accounts", "ci"]
+    }
+  }
+}
+```
+
+### Symbol
+
+A boolean value that allows for an using a unicode value rather than the default of gitmoji markup in a commit message. The default for symbol is false.
+
+```json
+{
+  "config": {
+    "cz-emoji": {
+      "symbol": true
     }
   }
 }
@@ -84,7 +95,7 @@ An [Inquirer.js] choices array:
 
 ## Examples
 
- - https://github.com/Falieson/TRAM
+- https://github.com/Falieson/TRAM
 
 ## Commitlint
 
@@ -95,30 +106,22 @@ npm install --save-dev commitlint-config-gitmoji
 ```
 
 _commitlint.config.js_
+
 ```js
 module.exports = {
-  extends: [
-    'gitmoji'
-  ],
+  extends: ["gitmoji"],
   parserPreset: {
     parserOpts: {
       headerPattern: /^(:\w*:)(?:\s)(?:\((.*?)\))?\s((?:.*(?=\())|.*)(?:\(#(\d*)\))?/,
-      headerCorrespondence: [
-        'type',
-        'scope',
-        'subject',
-        'ticket'
-      ],
+      headerCorrespondence: ["type", "scope", "subject", "ticket"]
     }
   }
 };
 ```
 
-
 ## License
 
 MIT © [Nicolas Gryman](http://ngryman.sh)
 
-
 [commitizen]: https://github.com/commitizen/cz-cli
-[Inquirer.js]: https://github.com/SBoudrias/Inquirer.js/
+[inquirer.js]: https://github.com/SBoudrias/Inquirer.js/


### PR DESCRIPTION
### Changes
#### :memo: (Readme) Adding Symbol Config [e0170f4]
Adding documentation for a configuration feature that was previously not shared. In the config there is a setting that allows for the unicode value (`types.emoji`) to be used rather than the gitmoji markup (`types.code`). In some cases it is preferred to use the unicode character rather than the gitmoji when it comes to performing a copy and paste of commit messages in some environments.
#### :memo: (Readme) Clean up Customization section  [c2a92ec]
Cleans up the flow and adds more words.
