### PR TITLE
📝 (readme) Add missed skipQuestion option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,7 +129,7 @@ An array of questions you want to skip:
 }
 ```
 
-You can skip the following questions: `scope`, `body`, and `issues`. The `type` and `subject` questions are mandatory.
+You can skip the following questions: `scope`, `body`, `issues`, and `breaking`. The `type` and `subject` questions are mandatory.
 
 
 #### Customize Questions


### PR DESCRIPTION
Was looking for a way to disable `A BREAKING CHANGE commit requires a body. Please enter a longer description of the commit itself:` message and [found option in the code](https://github.com/ngryman/cz-emoji/blob/master/index.js#L138).

But it was undocumented in the Readme. So this PR fixes this.

Btw, great project! 🆒 