### PR TITLE
✨feat(config) add option to customize commit message

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,16 @@ async function getConfig() {
   const loadedConfig =
     (await loadConfigUpwards('package.json')) ||
     (await loadConfigUpwards('.czrc')) ||
-    (await loadConfig(path.join(homedir(), '.czrc')))
+    (await loadConfig(path.join(homedir(), '.czrc'))) ||
+    {}
 
-  const config = { ...defaultConfig, ...loadedConfig }
-  config.format = config.conventional ? conventionalFormat : defaultFormat
+  const config = {
+    ...defaultConfig,
+    ...{
+      format: loadedConfig.conventional ? conventionalFormat : defaultFormat
+    },
+    ...loadedConfig
+  }
 
   return config
 }
@@ -156,18 +162,18 @@ function formatCommitMessage(answers, config) {
   const { columns } = process.stdout
 
   const emoji = answers.type
-  const type = types.find(type => type.code === emoji.emoji).name
+  const type = config.types.find(type => type.code === emoji.emoji).name
   const scope = answers.scope ? '(' + answers.scope.trim() + ')' : ''
   const subject = answers.subject.trim()
 
   const commitMessage = config.format
-    .replace('{emoji}', emoji.emoji)
-    .replace('{type}', type)
-    .replace('{scope}', scope)
-    .replace('{subject}', subject)
+    .replace(/{emoji}/g, emoji.emoji)
+    .replace(/{type}/g, type)
+    .replace(/{scope}/g, scope)
+    .replace(/{subject}/g, subject)
     // Only allow at most one whitespace.
     // When an optional field (ie. `scope`) is not specified, it can leave several consecutive
-    // whitespaces in the final message.
+    // white spaces in the final message.
     .replace(/\s+/g, ' ')
 
   const head = truncate(commitMessage, columns)

--- a/index.js
+++ b/index.js
@@ -165,6 +165,10 @@ function formatCommitMessage(answers, config) {
     .replace('{type}', type)
     .replace('{scope}', scope)
     .replace('{subject}', subject)
+    // Only allow at most one whitespace.
+    // When an optional field (ie. `scope`) is not specified, it can leave several consecutive
+    // whitespaces in the final message.
+    .replace(/\s+/g, ' ')
 
   const head = truncate(commitMessage, columns)
   const body = wrap(answers.body || '', columns)
@@ -187,11 +191,11 @@ function formatCommitMessage(answers, config) {
  * @return {String} Git message provided by the user
  */
 async function promptCommitMessage(cz) {
-    cz.prompt.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'))
-    cz.prompt.registerPrompt('maxlength-input', require('inquirer-maxlength-input-prompt'))
+  cz.prompt.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'))
+  cz.prompt.registerPrompt('maxlength-input', require('inquirer-maxlength-input-prompt'))
 
   const config = await getConfig()
-    const questions = createQuestions(config)
+  const questions = createQuestions(config)
   const answers = await cz.prompt(questions)
   const message = formatCommitMessage(answers, config)
 


### PR DESCRIPTION
It looks like #53 became stale, so I finished it here.
Kudos to @AndreAugustoAAQ for starting this!

This PR mostly fixes a couple of regressions:
* The script was crashing because the config object was `undefined`.
* Now we've introduced a user-provided format, optional fields (ie. `scope`) can leave multiple consecutive whitespaces when not provided. I prevented multiple spaces in the finale commit message, which is I believe a good way to sanitize the message anyway.

@AndreAugustoAAQ, @luizcorreia, @rossignolli Could you take a look at this as you were involved in the previous PR?
Thanks!

---
Fixes #51 #52 #53 #43 #31 #32
