### PR TITLE
🐛 compare name instead of emoji when using symbol

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ function formatCommitMessage(answers, config) {
   const { columns } = process.stdout
 
   const emoji = answers.type
-  const type = config.types.find(type => type.code === emoji.emoji).name
+  const type = config.types.find(type => type.name === emoji.name).name
   const scope = answers.scope ? '(' + answers.scope.trim() + ')' : ''
   const subject = answers.subject.trim()
 


### PR DESCRIPTION
fixes #76: 

`type.code` is a string like `:sparkles:`. 
`emoji.emoji` is a string like `✨` (when `symbol` is `true`). 

So find results in undefined and the function fails.