### PR TITLE
Fix commitlint config regexp in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@ const isConventional = pkg.config ? pkg.config['cz-emoji']?.conventional : false
 
 // Regex for default and conventional commits.
 const RE_DEFAULT_COMMIT = /^(?::.*:|(?:\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))\s(?<emoji>\((?<scope>.*)\)\s)?.*$/gm
-const RE_CONVENTIONAL_COMMIT = /^^(?<type>\w+)(?:\((?<scope>\w+)\))?\s(?<emoji>:.*:|(?:\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))\s.*$/gm
+const RE_CONVENTIONAL_COMMIT = /^(?<type>\w+)(?:\((?<scope>\w+)\))?:\s(?<emoji>:.*:|(?:\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]))\s.*$/gm
 
 module.exports = {
   rules: {


### PR DESCRIPTION
There is a mistake in the commitling.config.js snippet's regular expression for matching the conventional commit style in the readme.

It is missing a match for a colon after the scope and has a repeated beginning-of-string match caret. These are likely typos.